### PR TITLE
Moved to Github from Bitbucket

### DIFF
--- a/source/book_usage.rst
+++ b/source/book_usage.rst
@@ -6,7 +6,7 @@ Sphinxを使用して執筆された書籍です。ただ、Sphinxの出力そ�
 
 .. note::
 
-   もしも、ここに掲載していないものがありましたら、 `ここのチケット <http://bitbucket.org/sphinxjp/website/issues>`_ でご一報ください。
+   もしも、ここに掲載していないものがありましたら、 `ここのチケット <https://github.com/sphinxjp/sphinx-users.jp/issues>`_ でご一報ください。
 
 
 * IT業界を楽しく生き抜くための「つまみぐい勉強法」: http://gihyo.jp/book/2010/978-4-7741-4259-3

--- a/source/index.rst
+++ b/source/index.rst
@@ -48,7 +48,7 @@ Sphinx-Users.jpでは、日本で散らばっているSphinx関連情報を集�
 また、Sphinx-Users.jpでは定期的にイベントを開催しています。
 イベントの開催情報は、Twitterの `SphinxUsers.jp公式アカウント <http://twitter.com/sphinxjp>`_ でも呟きます。また、コミュニティのハッシュタグは `#sphinxjp <http://twitter.com/#search?q=%23sphinxjp>`_ になります。
 
-もし、ここに掲載している内容にミスが見つかったり、追加のコンテンツの希望、もしくは「これを載せて」という方は、このサイトのソースをホスティングしている、Bitbukcet内の `課題トラッカー <http://bitbucket.org/sphinxjp/website/issues?status=new&status=open>`_ のチケットを作成してください。
+もし、ここに掲載している内容にミスが見つかったり、追加のコンテンツの希望、もしくは「これを載せて」という方は、このサイトのソースをホスティングしている、Github内の `課題トラッカー <https://github.com/sphinxjp/sphinx-users.jp/issues>`_ のチケットを作成してください。
 
 
 .. サイトマップ


### PR DESCRIPTION
リポジトリが Bitbucket から移転していたので、 Issue tracker のリンクを張り直しました。
/source/cookbook/translation.rst はすでに Transifex を利用している旨注釈されていることから、そのままにしてあります。