### PR TITLE
update information about latex installation

### DIFF
--- a/source/cookbook/pdf/index.rst
+++ b/source/cookbook/pdf/index.rst
@@ -120,3 +120,4 @@ PDFの完成
 :2014/01/26: MacPortsによるOSXへのインストール、FreeBSDへのインストールを追加し、記事を再構成&更新 (波田野)
 :2017/02/23: ``make latexpdfja`` -> ``make latexpdf`` (渋川)
 :2018/08/19: 古い情報を削除 (うさ)
+:2019/11/29: LaTeXのインストールについてWindows、macOS、Linuxの情報を更新（hidaruma）

--- a/source/cookbook/pdf/latex-install-linux.rst
+++ b/source/cookbook/pdf/latex-install-linux.rst
@@ -2,21 +2,51 @@
 LinuxへのTeX Liveインストール
 ========================================
 
+幾つかのディストリビューションでは、システムのパッケージマネージャから
+TeX Live のインストールを行うことができます。TeX Liveは巨大なパッケージ群なので、
+用途に合わせて幾つかに分割したパッケージがあります。ここでは、日本語用のLaTeXである
+pLaTeX 系を使うためのパッケージを紹介しています。
 
 Debian/GNU Linux 7.0 (wheezy)
 ==============================
 
-Debian/GNU Linux 7.0 (wheezy) では TeX Live 2012 がパッケージングされているため、
+Debian/GNU Linux 10.0 (buster) では TeX Live 2018 がパッケージングされているため、
 apt-get コマンド経由で TeX Live をインストールすることができます。
 
 .. code-block:: bash
 
-   $ sudo apt-get install texlive texlive-lang-cjk
+   $ apt-get install texlive-latex-recommended \
+      texlive-latex-extra \
+      texlive-fonts-recommended \
+      texlive-fonts-extra \
+      texlive-lang-japanese \ 
+      texlive-lang-cjk 
 
-Ubuntu 14.04 (trusty)
+Ubuntu 18.04 (bionic)
 ======================
 
-Ubuntu 14.04 (trusty) では TeX Live 2013 がパッケージングされているため、
+Ubuntu 18.04 (bionic) では TeX Live 2018 がパッケージングされているため、
 apt-get コマンド経由で TeX Live をインストールすることができます。
 
-   $ apt-get install texlive texlive-lang-cjk
+.. code-block:: bash
+
+   $ apt-get install texlive-latex-recommended \
+      texlive-latex-extra \
+      texlive-fonts-recommended \
+      texlive-fonts-extra \
+      texlive-lang-japanese \ 
+      texlive-lang-cjk 
+
+
+.. note:: TeXのパッケージ関連で「○○がない」というエラーが出たら
+          
+          多くの場合、フルパッケージの TeX Live を入れると必要なものが入ります。
+          ただし、4GiB以上の容量を必要とします。
+          インストール先のストレージ容量に余裕があれば、フル版を入れることを検討してください。
+          Debian/Ubuntu系であれば以下のようになります。
+
+            $ apt-get install texlive-full
+
+         とはいえ、細かいTeXのパッケージのチューニングが必要となる場合、
+         システムのパッケージマネージャを用いず、isoやネットワークインストールを用いるべきです。
+         TeX Liveのドキュメント（https://www.tug.org/texlive/doc/texlive-ja/texlive-ja.pdf）を参照してください。

--- a/source/cookbook/pdf/latex-install-linux.rst
+++ b/source/cookbook/pdf/latex-install-linux.rst
@@ -7,7 +7,7 @@ TeX Live のインストールを行うことができます。TeX Liveは巨大
 用途に合わせて幾つかに分割したパッケージがあります。ここでは、日本語用のLaTeXである
 pLaTeX 系を使うためのパッケージを紹介しています。
 
-Debian/GNU Linux 7.0 (wheezy)
+Debian/GNU Linux 10.0 (buster)
 ==============================
 
 Debian/GNU Linux 10.0 (buster) では TeX Live 2018 がパッケージングされているため、
@@ -15,7 +15,7 @@ apt-get コマンド経由で TeX Live をインストールすることがで�
 
 .. code-block:: bash
 
-   $ apt-get install texlive-latex-recommended \
+   $ sudo apt-get install texlive-latex-recommended \
       texlive-latex-extra \
       texlive-fonts-recommended \
       texlive-fonts-extra \
@@ -25,12 +25,12 @@ apt-get コマンド経由で TeX Live をインストールすることがで�
 Ubuntu 18.04 (bionic)
 ======================
 
-Ubuntu 18.04 (bionic) では TeX Live 2018 がパッケージングされているため、
+Ubuntu 18.04 (bionic) では TeX Live 2017 がパッケージングされているため、
 apt-get コマンド経由で TeX Live をインストールすることができます。
 
 .. code-block:: bash
 
-   $ apt-get install texlive-latex-recommended \
+   $ sudo apt-get install texlive-latex-recommended \
       texlive-latex-extra \
       texlive-fonts-recommended \
       texlive-fonts-extra \
@@ -45,7 +45,7 @@ apt-get コマンド経由で TeX Live をインストールすることがで�
           インストール先のストレージ容量に余裕があれば、フル版を入れることを検討してください。
           Debian/Ubuntu系であれば以下のようになります。
 
-            $ apt-get install texlive-full
+            $ sudo apt-get install texlive-full
 
          とはいえ、細かいTeXのパッケージのチューニングが必要となる場合、
          システムのパッケージマネージャを用いず、isoやネットワークインストールを用いるべきです。

--- a/source/cookbook/pdf/latex-install-osx.rst
+++ b/source/cookbook/pdf/latex-install-osx.rst
@@ -1,13 +1,21 @@
-===============================================
-OSXへのTeX Liveインストール (MacTex / MacPorts)
-===============================================
+=======================================================
+OSX / macOSへのTeX Liveインストール (MacTex / MacPorts)
+=======================================================
 
 OSX 向けには `MacTeX <http://www.tug.org/mactex/>`_ というディストリビューションが提供されています。
 
-また、2014年1月時点で、macportsで最新のTeX Live2013のインストールが可能です。
+また、2019年11月時点で、macports、Homebrewで最新のTeX Live2019のインストールが可能です。
 
-OSXユーザの方は、TeX LiveかMacTeXのいずれかをインストールしてください。
+OSX / macOS ユーザの方は、TeX LiveかMacTeXのいずれかをインストールしてください。
 (両方インストールするとコマンドがコンフリクトする可能性があります。)
+
+.. warning:: TeX LiveよりMacTeXを
+
+             OSX / macOS に標準でインストールされているヒラギノフォントは OSX / macOS 
+             のバージョンによって設定が異なり、パッチを当ててTeX側が対処しているため、
+             TeX Liveの挙動を把握していない場合は
+             OSX / macOS 用に調整された MacTeX の使用を推奨します。
+
 
 MacPortsによる TeX Live のインストール
 =======================================
@@ -28,3 +36,20 @@ MacPortsでインストールする場合、必ず ``+full`` オプションを�
 
   ビルドに1時間近くかかります。
 
+
+HomebrewによるMacTeXのインストール
+==================================
+
+.. code-block:: bash
+
+    $ brew cask install mactex-no-gui
+    $ sudo tlmgr update --self --all
+
+..note:: BasicTeX
+         
+         OSX / macOS 用のTeX Liveディストリビューションには他にBasicTeXがあります。
+         パッケージのサイズはMacTeXよりも小さくなりますが、日本語環境を別にインストールする必要があります。
+         Homebrewの場合は以下のようになります。
+
+           $ brew cask install basictex
+           $ sudo tlmgr update --self --all

--- a/source/cookbook/pdf/latex-install-tl.rst
+++ b/source/cookbook/pdf/latex-install-tl.rst
@@ -12,8 +12,12 @@ TeX 環境の構築
 TeX 環境は TeX のディストリビューション「TeX Live」のインストールを推奨します。最新版の TeX Live [#texlive]_ をインストールしましょう。
 開発元が推奨しているのはネットワークインストーラの利用ですが、ISO イメージをダウンロードしてインストールするのが確実です。
 
+TeX Live の主要なOS環境でのインストール手順については、 TeX Live 公式のマニュアルの
+日本語版（https://www.tug.org/texlive/doc/texlive-ja/texlive-ja.pdf）が存在します。
+
+
 以下は Windows へのインストール例ですが、UNIX 系 OS でターミナルからインストールする際は CUI で表示されるだけで、
-ほぼ同様の手順で進められますのでコマンドや環境については適宜読みかえて下さい。
+ほぼ同様の手順で進められますのでコマンドや環境については適宜読みかえて下さい。TeX Live2016を例として説明します。
 
 1. 配布サイトにアクセスし「download from a nearby CTAN mirror」をクリックします。アクセス元から最適なダウンロード先が表示されます。
 
@@ -81,7 +85,7 @@ TeX のパッケージが改良されていたり増えたりする事もあり�
 
 Windows 以外の OS へのインストールについては TeX Wiki [#texlive-install]_ を確認して下さい。
 
-.. [#texlive] 2016年10月現在の最新版は TeX Live 2016
+.. [#texlive] 2019年11月現在の最新版は TeX Live 2019
 .. [#virtualclonedrive] Virtual CloneDrive http://www.elby.ch/
 .. [#wincdemu] Win CDEmu http://wincdemu.sysprogs.org/
 .. [#texlive-install] TeX Wiki https://texwiki.texjp.org/ TeX をインストールしよう → TeX 入手法 → TeX をインストールする方法


### PR DESCRIPTION
* latex-install-osx.rst: macOSの表記を追加、 Homebrewでのインストール方法、note、warningを追加。
* latex-install-linux: Ubuntuの項を最新LTSの18.04での情報に更新、Debianの項をbusterのものに更新。パッケージについてはsphinxjpのDockerに合わせるようにした。 noteを追加。
* latex-install-tl: 最新版が2019であることを表記。更新履歴追加。<del>（現在であればWin, mac, Linuxどれでもインストール難度が下がっているのでよりプッシュしたいのですが）</del>

FreeBSDについては未確認のため更新せず。