### PR TITLE
🚧 🎨 layout of page 🆙 #47 🚧

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
 Sphinx
-sphinxjp.themes.sphinxjp
+git+https://github.com/sphinxjp/sphinxjp.themes.sphinxjp.git
 setuptools
 sphinxcontrib.gist

--- a/source/_templates/globalnavigation.html
+++ b/source/_templates/globalnavigation.html
@@ -7,12 +7,3 @@
     :copyright: Copyright 2011 by the sphinx-users.jp team, see AUTHORS.
     :license: MIT, see LICENSE for details.
 #}
-<div id="gnav">
-  <ul>
-    <li class="home"><p><a href="{{ pathto('index') }}" title="{{ project }}">{{ project }}</a></p></li>
-    <li class="doc"><p><a href="https://www.sphinx-doc.org/ja/master/" title="リファレンスマニュアル">リファレンスマニュアル</a></p></li>
-    <li class="modindex">
-      <p><a title="{{ _('Index') }}" href="{{ pathto('genindex') }}">{{ _('Index') }}</a></p>
-    </li>
-  </ul>
-</div>

--- a/source/_templates/reference.html
+++ b/source/_templates/reference.html
@@ -12,5 +12,6 @@
     <li><a class="manual-btn" href="https://www.sphinx-doc.org/ja/master/">Sphinx リファレンスマニュアル</a></li>
     <li><a class="manual-btn" href="http://docutils.sphinx-users.jp/">Docutils(reST) マニュアル</a></li>
     <li><a class="manual-btn" href="http://quick-restructuredtext.readthedocs.io/">早わかりreStructuredText</a></li>
+    <li><a class="manual-btn" href="https://sphinx-users.jp/genindex.html">索引</a></li>
   </ul>
 </div>


### PR DESCRIPTION
#47 バーのコンテンツを削除しましたが、バーそのものは残っています。テーマを変更すれば消えるでしょうか？索引はTable Of Contentsの上にボタンとして残しました。Table Of Contentsの下にする案もあるかもしれません。
![image](https://user-images.githubusercontent.com/7513610/71322515-99988900-250b-11ea-9d20-6d8b9aa1bddd.png)
