### PR TITLE
fix awscli installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
           aws --version
           # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html
           aws s3 sync ${SOURCE_DIR} s3://${AWS_S3_BUCKET}/${DEST_PATH} --acl public-read --delete


### PR DESCRIPTION
https://github.com/sphinxjp/sphinx-users.jp/runs/2157177786

GitHub Actions で提供するコンテナにawscli v1 がインストール済みとなったため、 `sudo ./aws/install --update` のようにupdateフラグを指定してv2をインストールする