### PR TITLE
🗑 Slack通知を削除

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,16 +53,6 @@ jobs:
       - name: build html
         run: |
           /home/runner/.local/bin/sphinx-build -M html source build -N -T
-      - name: slack-notifier
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: workflow
-          author_name: sphinx-build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()
       - name: s3sync
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
現状、稼働せずにエラーとなっているので削除してはいかがでしょう。