### PR TITLE
Sphinx-Users.jpから外部サイトへのリンクをブラウザの別のタブで開くようにする

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
 pygments>=2.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
 sphinx>=3.0.4 # not directly required, pinned by Snyk to avoid a vulnerability
 sphinxext-opengraph
+sphinx-new-tab-link

--- a/source/conf.py
+++ b/source/conf.py
@@ -27,6 +27,7 @@ extensions = [
     'sphinxcontrib.trimblank',
     'sphinxext.opengraph',
     'sphinxcontrib.gist',
+    'sphinx_new_tab_link',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
自作したSphinx拡張を使えば外部サイトへのリンクをブラウザの別のタブで開くようにできます。
⌘+クリックやCtrl+クリックから開放された状態で閲覧できると私は嬉しいので提案させていただきました。
有用そうでしたら採用いただければと思います。

プルリクエストにあたり、以下を確認しています

* `make html` でビルドできる（壊していないことの確認の意図）
* index.html (https://sphinx-users.jp/ )の以下のリンクがブラウザの別のタブで開く（自作拡張が機能していることの確認の意図）
  * >ご自由に [slack](https://join.slack.com/t/sphinxjp/shared_invite/enQtNzkxMTIwMTAzOTI2LTMxY2JjMmM4OWNjNjM1YjdkMGE5N2UyYjY1NzM5MTY1NGM3YmVmMjliM2MyYmQ0ZjhlZjRmMGM5NTA5N2MwZjY) にご参加ください。
  * >もしくは「これを載せて」という方は、このサイトのソースをホスティングしている、GitHub内の[課題トラッカー](https://github.com/sphinxjp/sphinx-users.jp/issues) のチケットを作成してください。