### PR TITLE
採用事例の追加もGitHub上での管理となっていることの記述

### DIFF
--- a/source/howtojoin.rst
+++ b/source/howtojoin.rst
@@ -59,9 +59,9 @@ Sphinxは確かにPythonで書かれていますが、Sphinxの拡張機能を�
 
    - * 採用事例に自分の例も追加して欲しい
      * * 採用された事例やテンプレート 
-       * Bitbucketへのユーザ登録
-       * Mercurial(hg)を使う能力
-       * Bitbucketでforkして、PullRequestを出す勇気
+       * GitHubへのユーザ登録
+       * gitを使う能力
+       * GitHubでforkして、Pull Requestを出す勇気
 
 .. rubric:: 脚注
 .. [#] 現状ではSphinxのソースや、Docutilsの英語資料を読む必要があります。


### PR DESCRIPTION
[参加するには？ > 必要なスキルは？](https://sphinx-users.jp/howtojoin.html#id20) のテーブル内で、「自分のノウハウを#sphinxjpのサイトに公開したい」側だけがGitHubになっていたので、統一のための編集です。

※他の各種ページにもGitHubへの編集を行えそうな箇所はありましたが、ひとまずこれだけとなっています。
