### PR TITLE
GitHub Actions のバージョン更新

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'  # to get full commit logs for 'git-set-file-times'
       - name: DEBUG INFO github refs
@@ -19,8 +19,8 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-          echo "::set-output name=yyyymm::$(/bin/date -u "+%Y%m")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+          echo "yyyymm=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT 
         shell: bash
       - name: git-set-file-times
         # change timestamps with commit time instead of checkout time.
@@ -29,7 +29,7 @@ jobs:
           ./.github/git-set-file-times.py
       - name: CACHE pip
         id: cache-pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -37,7 +37,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ steps.get-date.outputs.yyyymm }}
       - name: CACHE sphinx build
         id: cache-sphinx-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: build
           key: ${{ runner.os }}-sphinx-build-${{ github.ref }}-${{ steps.get-date.outputs.date }}


### PR DESCRIPTION
別のリポジトリでの更新内容を持ってきました

- `actions/checkout@v2` -> `actions/checkout@v4`
- `actions/cache@v2` -> `actions/cache@v3`
- `::set-output` -> ` >> $GITHUB_OUTPUT`

参考

- https://github.com/sphinx-doc/sphinx-doc-translations/pull/25
- https://github.com/sphinx-doc/sphinx-doc-translations/pull/29
