### PR TITLE
github actions バージョン更新検知 #136

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+       # Name for the group, which will be used in PR titles and branch names
+       all-github-actions:
+          # Group all updates together
+          patterns:
+            - "*"


### PR DESCRIPTION
Sphinxプロジェクトからもらってきました
https://github.com/sphinx-doc/sphinx-doc-translations/blob/master/.github/dependabot.yml

ドキュメントを見ると色々あるようですが、とりあえずactionsだけ有効にすればいいかなと思います
https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
