### PR TITLE
2024総会を追加

### DIFF
--- a/source/event/20231208_general_meeting/index.rst
+++ b/source/event/20231208_general_meeting/index.rst
@@ -9,18 +9,18 @@ sphinx-users.jp 2023年総会(2023/12/08)
 
 .. __: https://www.its-kenpo.or.jp/fuzoku/restaurant/alfaro/index.html
 
-2023年のsphinx-users.jp総会を行います。
+2023年のsphinx-users.jp総会を行いました。
 
 総会の開催について、詳しくは :doc:`../../regulations` を参照してください。
 
 参加方法
 =========
 
-connpassで参加者を募集中です。
+.. connpassで参加者を募集中です。
 
 * https://sphinxjp.connpass.com/event/296761/
 
-.. Slackで日程を調整し、connpassで参加者を募集しました。
+Slackで日程を調整し、connpassで参加者を募集しました。
 
 アジェンダ
 ==========
@@ -74,12 +74,12 @@ connpassで参加者を募集中です。
   :副会長: 募集中
   :会計: 募集中
 
-.. * 決定:
-..
-..   :会長: @usaturn
-..   :副会長: @usaturn
-..   :副会長: @usaturn
-..   :会計: @shimizukawa
+* 決定:
+
+  :会長: @tkoyama010 （小山）
+  :副会長: @usaturn （山田）
+  :副会長: @shibu_jp （渋川）
+  :会計: @shimizukawa （清水川）
 
 
 約例の変更

--- a/source/event/202412_general_meeting/index.rst
+++ b/source/event/202412_general_meeting/index.rst
@@ -1,0 +1,205 @@
+========================================
+sphinx-users.jp 2024年総会(2024/12/xx)
+========================================
+
+:日時: 2024/12/xx 20:00～22:00
+:場所: 予定中
+:参加費: 5000円前後（運営費カンパ含む）
+:持ち物: 関東IT健保の方は保険証
+
+.. .. __: https://www.its-kenpo.or.jp/fuzoku/restaurant/alfaro/index.html
+
+2024年のsphinx-users.jp総会を行います。
+
+総会の開催について、詳しくは :doc:`../../regulations` を参照してください。
+
+参加方法
+=========
+
+connpassで参加者を募集中です。
+
+* URL: 準備中
+
+.. * https://sphinxjp.connpass.com/event/296761/
+
+.. Slackで日程を調整し、connpassで参加者を募集しました。
+
+アジェンダ
+==========
+
+* カンパイ
+* 会長挨拶、参加者自己紹介
+* 役員の改選
+* 約例の変更
+* 会計報告
+
+.. 総会の様子
+.. ==========
+..
+.. 議事進行
+.. ---------
+..
+.. * カンパイ
+.. * 会長挨拶、参加者自己紹介
+.. * 役員の改選
+.. * 約例の変更
+.. * 会計報告
+.. * 今年やったこと、来年やりたいこと
+..
+.. 会長挨拶、参加者自己紹介
+.. ---------------------------------
+..
+.. @tkoyama010: （会長挨拶）
+..
+.. @usaturn: （副会長）
+..
+.. @shimizukawa: （副会長）
+..
+
+役員の改選
+----------
+
+* 2024年度:
+
+  :会長: @tkoyama010 （小山）
+  :副会長: @usaturn （山田）
+  :副会長: @shibu_jp （渋川）
+  :会計: @shimizukawa （清水川）
+
+* 2025年度 役員立候補・推薦:
+
+  :会長: 募集中
+  :副会長: 募集中
+  :副会長: 募集中
+  :会計: 募集中
+
+.. * 決定:
+..
+..   :会長: @usaturn
+..   :副会長: @usaturn
+..   :副会長: @usaturn
+..   :会計: @shimizukawa
+
+
+約例の変更
+----------
+
+以下のように提案します。
+
+* 本部住所を次の住所へ変更します。
+
+  * 現: 〒170-0013 東京都豊島区東池袋
+  * 新: 〒170-6045 東京都豊島区東池袋
+
+* 満場一致で可決しました
+
+会計報告
+--------
+
+* 2023年からの繰り越し: 30,208 円
+* 収入(2024/1/1 - 10/13): 0 円
+* 支出(2024/1/1 - 10/13): -967 円
+* 収支(2024/1/1 - 10/13): -967 円
+* 残金(2024/10/21時点): 29,241 円
+
+支出の概要:
+
+* S3/CloudFrontの利用料(約96.7円/月、12ヶ月で1160円予定)
+
+.. 本日(12/16)の寄付額は、x,xxx円 でした。
+..
+.. 収支詳細
+.. ----------------
+..
+.. .. list-table::
+..    :header-rows: 1
+..
+..    - *
+..      * 収入
+..      * 支出
+..
+..    - * 2021年から繰り越し
+..      * 13,487
+..      *
+..
+..
+..    - * 2024/01/02  sphinx-users.jp AWSレンタル 2021年12月
+..      *
+..      * 74
+..
+..    - * 2024/02/03  sphinx-users.jp AWSレンタル 2022年1月
+..      *
+..      * 74
+..
+..    - * 2024/03/03  sphinx-users.jp AWSレンタル 2022年2月
+..      *
+..      * 75
+..
+..    - * 2024/04/03  sphinx-users.jp AWSレンタル 2022年3月
+..      *
+..      * 80
+..
+..    - * 2024/05/03  sphinx-users.jp AWSレンタル 2022年4月
+..      *
+..      * 84
+..
+..    - * 2024/06/02  sphinx-users.jp AWSレンタル 2022年5月
+..      *
+..      * 84
+..
+..    - * 2024/07/03  sphinx-users.jp AWSレンタル 2022年6月
+..      *
+..      * 87
+..
+..    - * 2024/08/02  sphinx-users.jp AWSレンタル 2022年7月
+..      *
+..      * 85
+..
+..    - * 2024/09/03  sphinx-users.jp AWSレンタル 2022年8月
+..      *
+..      * 87
+..
+..    - * 2024/10/03  sphinx-users.jp AWSレンタル 2022年9月
+..      *
+..      * 93
+..
+..    - * 2024/11/03  sphinx-users.jp AWSレンタル 2022年10月
+..      *
+..      * 95
+..
+..    - * 2024/12/03  sphinx-users.jp AWSレンタル 2022年11月
+..      *
+..      *
+..
+..    - * 2024/12/16  sphinx-users.jp 総会 会員寄付
+..      * x,xxxx
+..      *
+..
+..    - * 2024 累計
+..      * x,xxx
+..      * x,xxx
+..
+..    - * 2025年への繰り越し(予定)
+..      * xx,xxx
+..      *
+..
+.. 今年やったこと、来年やりたいこと
+.. ----------------------------------------
+..
+.. 雑談
+.. -----------------
+..
+.. 会場の様子
+.. -----------
+..
+.. .. figure:: attendees.*
+..    :width: 80%
+..
+..    参加者のみなさん
+..
+..
+.. その他の写真はこちら
+..
+.. .. raw:: html
+..
+..    <iframe style="position: relative; top: 0; left: 0; width: 100%; height: 100%;" src="https://flickrembed.com/cms_embed.php?source=flickr&layout=fixed&input=www.flickr.com/photos/shimizukawa/sets/72157702819306851&sort=0&by=album&width=800&height=500&theme=default&scale=fill&speed=3000&limit=10&skin=default&autoplay=true" scrolling="no" frameborder="0" allowFullScreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"><p><a  href="https://s3.amazonaws.com/tui-discount-codes/index.html">https://s3.amazonaws.com/tui-discount-codes/index.html</a></p><small>Powered by <a href="https://flickrembed.com">flickr embed</a>.</small></iframe><script type="text/javascript">function showpics(){var a=$("#box").val();$.getJSON("http://api.flickr.com/services/feeds/photos_public.gne?tags="+a+"&tagmode=any&format=json&jsoncallback=?",function(a){$("#images").hide().html(a).fadeIn("fast"),$.each(a.items,function(a,e){$("<img/>").attr("src",e.media.m).appendTo("#images")})})}</script>

--- a/source/event/202412_general_meeting/index.rst
+++ b/source/event/202412_general_meeting/index.rst
@@ -2,12 +2,12 @@
 sphinx-users.jp 2024年総会(2024/12/xx)
 ========================================
 
-:日時: 2024/12/xx 20:00～22:00
-:場所: 予定中
+:日時: 2024/12/09 20:00～22:00
+:場所: `関東IT健保 桜華楼 @ 大久保`__
 :参加費: 5000円前後（運営費カンパ含む）
 :持ち物: 関東IT健保の方は保険証
 
-.. .. __: https://www.its-kenpo.or.jp/fuzoku/restaurant/alfaro/index.html
+.. __: https://www.its-kenpo.or.jp/fuzoku/restaurant/oukarou/index.html
 
 2024年のsphinx-users.jp総会を行います。
 
@@ -18,9 +18,7 @@ sphinx-users.jp 2024年総会(2024/12/xx)
 
 connpassで参加者を募集中です。
 
-* URL: 準備中
-
-.. * https://sphinxjp.connpass.com/event/296761/
+* https://sphinxjp.connpass.com/event/335055/
 
 .. Slackで日程を調整し、connpassで参加者を募集しました。
 
@@ -91,7 +89,7 @@ connpassで参加者を募集中です。
   * 現: 〒170-0013 東京都豊島区東池袋
   * 新: 〒170-6045 東京都豊島区東池袋
 
-* 満場一致で可決しました
+.. * 満場一致で可決しました
 
 会計報告
 --------

--- a/source/event/index.rst
+++ b/source/event/index.rst
@@ -5,6 +5,14 @@
 
 こちらは過去のイベントレポートのページです。募集中のイベントなど、最新のイベント情報については、Connpassの `シリーズ：Sphinx-users.jp <http://sphinxjp.connpass.com/>`_ で確認して下さい。Sphinx-Users.jpでは、イベントの募集に `connpass <https://connpass.com/dashboard/>`_ を利用しています。
 
+2024年
+------
+
+.. toctree::
+   :maxdepth: 1
+
+   202412_general_meeting/index
+
 2023年
 ------
 


### PR DESCRIPTION
総会の案内を出します。

## タイムライン

* 2024/11/02（土） ～ 2024/12/01（日）役員推薦
* 2024/12/09（月） 20:00～22:00 総会:  役員の選出投票、決算の承認


参考リンク https://github.com/sphinxjp/sphinx-users.jp/pull/108