### PR TITLE
Update link.rst: `:doc:`ディレクティブのサンプルコードを修正

### DIFF
--- a/source/reverse-dict/writing/link.rst
+++ b/source/reverse-dict/writing/link.rst
@@ -84,7 +84,7 @@ reSTのインライン構文
 
 .. code-block:: rst
 
-   くわしい使い方は :doc:`../images/target.rst` に書かれています。
+   くわしい使い方は :doc:`../images/target` に書かれています。
 
 ~~~~~~
 適用例


### PR DESCRIPTION
`:doc:`ディレクティブのパスに拡張子を付けると、ビルド時に"unknown document"というメッセージが表示され、リンクは生成されません。 このサンプルコードではリンクは生成されなかっため、正しいパスに変更しました。