### PR TITLE
リダイレクト先が意図していないと思われるURLを本来のURLにする。

### DIFF
--- a/source/howtojoin.rst
+++ b/source/howtojoin.rst
@@ -92,9 +92,9 @@ Sphinx-Users.jpでコミュニティとして用意しているコミュニケ�
 Twitter
 -------
 
-Sphinx-Users.jpの公式ハッシュタグは `#sphinxjp <http://twitter.com/#!/search/%23sphinxjp>`_ です。このハッシュタグを付けて呟いたり、質問をすると、メンバーから回答があるかもしれません。ただし、Twitterの場合は流量が多いと流れてしまうため、質問する場合にはメーリングリストの方が確実です。
+Sphinx-Users.jpの公式ハッシュタグは `#sphinxjp <https://x.com/search?q=%23sphinxjp>`_ です。このハッシュタグを付けて呟いたり、質問をすると、メンバーから回答があるかもしれません。ただし、Twitterの場合は流量が多いと流れてしまうため、質問する場合にはメーリングリストの方が確実です。
 
-Sphinx-Users.jpの情報を呟く `@sphinxjp <http://twitter.com/#!/sphinxjp>`_ 公式アカウントもあります。
+Sphinx-Users.jpの情報を呟く `@sphinxjp <http://twitter.com/sphinxjp>`_ 公式アカウントもあります。
 
 .. _slack:
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -46,7 +46,7 @@ slack_ のコミュニケーションや :doc:`勉強会 <event/index>` の開�
 ご自由に slack_ にご参加ください。
 
 また、Sphinx-Users.jpでは定期的にイベントを開催しています。
-イベントの開催情報は、Twitterの `SphinxUsers.jp公式アカウント <https://twitter.com/sphinxjp>`_ でも呟きます。また、コミュニティのハッシュタグは `#sphinxjp <https://twitter.com/#search?q=%23sphinxjp>`_ になります。
+イベントの開催情報は、Twitterの `SphinxUsers.jp公式アカウント <https://twitter.com/sphinxjp>`_ でも呟きます。また、コミュニティのハッシュタグは `#sphinxjp <https://x.com/search?q=%23sphinxjp>`_ になります。
 
 もし、ここに掲載している内容にミスが見つかったり、追加のコンテンツの希望、もしくは「これを載せて」という方は、このサイトのソースをホスティングしている、GitHub内の `課題トラッカー <https://github.com/sphinxjp/sphinx-users.jp/issues>`_ のチケットを作成してください。
 


### PR DESCRIPTION
## 概要

X（Twitter）へのリンクのうち、「記載当初は正常だったが現時点でリダイレクト先が元URLの意図とずれている」と思わしきものについて、現在の適切そうなURLへ修正しています。

## スコープ外としたもの

* URLのうち、リダイレクトが適切に行われてていると思われるもの。（アカウントURLなど）
* サービス名称の変更自体への追従